### PR TITLE
Terraform porting patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@ install/
 cli/
 go.work
 go.work.backup
+go.work.sum
+go/
+pty/
+readline/
+speakeasy/
+terraform/
+go-userdirs/

--- a/buildenv
+++ b/buildenv
@@ -1,5 +1,5 @@
 # ls accordingly. Use bump check to confirm.
-# bump: terraform-version /TERRAFORM_VERSION="(.*)"/ https://github.com/hashicorp/terraform
+# bump: terraform-version /TERRAFORM_VERSION="(.*)"/ https://github.com/hashicorp/terraform.git|semver:*
 # TERRAFORM_VERSION="V.R.M" # Specify a stable release
 TERRAFORM_VERSION="1.7.3"
 

--- a/buildenv
+++ b/buildenv
@@ -1,7 +1,7 @@
-#ls accordingly. Use bump check to confirm.
-# bump: terraform-version /TERRAFORM_VERSION="(.*)"/ https://github.com/hashicorp/terraform.git|semver:*
+# ls accordingly. Use bump check to confirm.
+# bump: terraform-version /TERRAFORM_VERSION="(.*)"/ https://github.com/hashicorp/terraform
 # TERRAFORM_VERSION="V.R.M" # Specify a stable release
-TERRAFORM_VERSION="1.6.6"
+TERRAFORM_VERSION="1.7.3"
 
 export ZOPEN_BUILD_LINE="STABLE"
 
@@ -9,53 +9,87 @@ export ZOPEN_STABLE_TAG="v${TERRAFORM_VERSION}"
 export ZOPEN_STABLE_URL="https://github.com/hashicorp/terraform.git"
 export ZOPEN_STABLE_DEPS="comp_go wharf"
 
-export ZOPEN_CATEGORIES="development"
+export ZOPEN_CATEGORIES="devops"
 export ZOPEN_NAME="terraform"
-
-export ZOPEN_DEV_URL="https://github.com/hashicorp/terraform.git"
-export ZOPEN_DEV_DEPS="comp_go wharf"
-
-#export ZOPEN_RUNTIME_DEPS="go"
 
 export ZOPEN_COMP=GO
 export ZOPEN_CONFIGURE="zopen_wharf"
 export ZOPEN_CONFIGURE_MINIMAL=1
-
-#export ZOPEN_MAKE="go"
-#export ZOPEN_MAKE_OPTS="build"
-#export ZOPEN_MAKE_MINIMAL=1
-
+export ZOPEN_MAKE="skip"
 export ZOPEN_INSTALL="zopen_install"
-
 export ZOPEN_CHECK="skip"
 export ZOPEN_CLEAN="zopen_clean"
 
 zopen_init()
 {
+  echo "here-at-init $PWD"
+
   export CGO_ENABLED=0
+  export GOTMPDIR=$PWD/go-tmpdir
+  mkdir -p $PWD/go-tmpdir
   # Go installs binaries, so create the bin dir as well
-  export GOBIN=$ZOPEN_INSTALL_DIR/bin
   export PATH=$PATH:$GOROOT/go-build-zos/bin
-  mkdir -p $ZOPEN_INSTALL_DIR
+  export GOBIN=$ZOPEN_INSTALL_DIR/bin
+  mkdir -p $ZOPEN_INSTALL_DIR/bin
+  unset CC CXX
+}
+
+zopen_build()
+{
+  echo $PWD
+  go version
+  go build
 }
 
 zopen_wharf()
 {
+  PTY_TAG="v1.1.21"
+  cd .. && echo ""
+  git clone https://github.com/creack/pty.git
+  echo "Checking out $PTY_TAG"
+  cd pty && git -c advice.detachedHead=false checkout $PTY_TAG
+  curl -s -o pty--$PTY_TAG.patch "https://raw.githubusercontent.com/ZOSOpenTools/wharf/main/deps-patches/pty--$PTY_TAG.patch"
+  git apply -v pty--$PTY_TAG.patch
   cd ..
+ 
+  git clone https://github.com/apparentlymart/go-userdirs.git
+  cd go-userdirs; git apply -v --ignore-space-change --ignore-whitespace ../patches/userdirspatch; cd ..
 
-  go work init ./terraform
-  wharf ./terraform/...
-  cd ./terraform
+  git clone https://github.com/chzyer/readline.git  
+  cd readline; git apply -v --ignore-space-change --ignore-whitespace ../patches/readlinepatch; cd ..  
+  
+  git clone https://github.com/bgentry/speakeasy.git
+  cd speakeasy; git apply -v --ignore-space-change --ignore-whitespace ../patches/speakeasypatch; cd ..
+
+  go work init ./terraform ./go-userdirs ./readline ./pty
+  #wharf ./terraform/...
+
+  cd ./terraform 
+  # terraform path
+  git checkout -- internal/configs/configload/inode.go
+  git apply -v --ignore-space-change --ignore-whitespace ../patches/terraformpatch
+
+  echo "here-at-config $PWD"
 }
 
 zopen_install()
 {
-  go install -ldflags="-X 'main.Version=${TERRAFORM_VERSION}'"
+  echo "here-at-install $PWD"
+  echo "GOBIN is $GOBIN"
+  
+  go mod tidy
+  chmod -R 755 ../go/pkg/mod/github.com/bgentry/speakeasy@v0.1.0/
+  cp ../speakeasy/* ../go/pkg/mod/github.com/bgentry/speakeasy@v0.1.0/
+  cat ../go/pkg/mod/github.com/bgentry/speakeasy@v0.1.0/speakeasy_unix.go
+  
+  go install
 }
 
 zopen_clean()
 {
-  rm -rf ../.wharf_cache ../go.work* ../wharf_port
+  echo "here-at-clean $PWD"
+  chmod -R 755 ../go
+  rm -rf ../go* ../.wharf_cache ../go.work* ../wharf_port ../go-userdirs ../readline ../speakeasy ../pty
 }
 
 zopen_get_version()

--- a/patches/gouserdirspatch
+++ b/patches/gouserdirspatch
@@ -1,0 +1,30 @@
+diff --git a/userdirs/app_stub.go b/userdirs/app_stub.go
+index 7532199..b668b56 100644
+--- a/userdirs/app_stub.go
++++ b/userdirs/app_stub.go
+@@ -1,4 +1,4 @@
+-// +build !linux,!windows,!darwin,!aix,!dragonfly,!freebsd,!netbsd,!openbsd,!solaris
++// +build !linux,!windows,!darwin,!aix,!dragonfly,!freebsd,!netbsd,!openbsd,!solaris,!zos
+ 
+ // The above build constraint must contain the negation of all of the build
+ // constraints found in the other app_*.go files, to catch any other OS
+diff --git a/userdirs/app_unix.go b/userdirs/app_unix.go
+index 44493df..04e1f9d 100644
+--- a/userdirs/app_unix.go
++++ b/userdirs/app_unix.go
+@@ -1,4 +1,4 @@
+-// +build linux aix dragonfly freebsd netbsd openbsd solaris
++// +build linux aix dragonfly freebsd netbsd openbsd solaris zos
+ 
+ package userdirs
+ 
+diff --git a/userdirs/app_unix_test.go b/userdirs/app_unix_test.go
+index 727a5d1..72be0eb 100644
+--- a/userdirs/app_unix_test.go
++++ b/userdirs/app_unix_test.go
+@@ -1,4 +1,4 @@
+-// +build linux aix dragonfly freebsd netbsd openbsd solaris
++// +build linux aix dragonfly freebsd netbsd openbsd solaris zos
+ 
+ package userdirs
+ 

--- a/patches/readlinepatch
+++ b/patches/readlinepatch
@@ -1,0 +1,36 @@
+diff --git a/term.go b/term.go
+index ea5db93..77f06ad 100644
+--- a/term.go
++++ b/term.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build aix darwin dragonfly freebsd linux,!appengine netbsd openbsd os400 solaris
++// +build aix darwin dragonfly freebsd linux zos,!appengine netbsd openbsd os400 solaris
+ 
+ // Package terminal provides support functions for dealing with terminals, as
+ // commonly found on UNIX systems.
+diff --git a/term_nosyscall6.go b/term_nosyscall6.go
+index df92339..1c320fd 100644
+--- a/term_nosyscall6.go
++++ b/term_nosyscall6.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build aix os400 solaris
++// +build aix os400 solaris zos
+ 
+ package readline
+ 
+diff --git a/utils_unix.go b/utils_unix.go
+index fc49492..ddc6927 100644
+--- a/utils_unix.go
++++ b/utils_unix.go
+@@ -1,4 +1,4 @@
+-// +build aix darwin dragonfly freebsd linux,!appengine netbsd openbsd os400 solaris
++// +build aix darwin dragonfly freebsd linux zos,!appengine netbsd openbsd os400 solaris
+ 
+ package readline
+ 

--- a/patches/speakeasypatch
+++ b/patches/speakeasypatch
@@ -1,0 +1,13 @@
+diff --git a/speakeasy_unix.go b/speakeasy_unix.go
+index 59cb8c9..529f278 100644
+--- a/speakeasy_unix.go
++++ b/speakeasy_unix.go
+@@ -4,7 +4,7 @@
+ // Original code is based on code by RogerV in the golang-nuts thread:
+ // https://groups.google.com/group/golang-nuts/browse_thread/thread/40cc41e9d9fc9247
+ 
+-// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris zos
++// +build zos aix darwin dragonfly freebsd linux netbsd openbsd solaris
+ 
+ package speakeasy
+ 

--- a/patches/terraformpatch
+++ b/patches/terraformpatch
@@ -1,0 +1,15 @@
+diff --git a/internal/configs/configload/inode.go b/internal/configs/configload/inode.go
+index 0437b204e5..87df754142 100644
+--- a/internal/configs/configload/inode.go
++++ b/internal/configs/configload/inode.go
+@@ -1,8 +1,8 @@
+ // Copyright (c) HashiCorp, Inc.
+ // SPDX-License-Identifier: BUSL-1.1
+ 
+-//go:build linux || darwin || openbsd || netbsd || solaris || dragonfly
+-// +build linux darwin openbsd netbsd solaris dragonfly
++//go:build linux || darwin || openbsd || netbsd || solaris || dragonfly || zos
++// +build linux darwin openbsd netbsd solaris dragonfly zos 
+ 
+ package configload
+ 

--- a/patches/userdirspatch
+++ b/patches/userdirspatch
@@ -1,0 +1,30 @@
+diff --git a/userdirs/app_stub.go b/userdirs/app_stub.go
+index 7532199..b668b56 100644
+--- a/userdirs/app_stub.go
++++ b/userdirs/app_stub.go
+@@ -1,4 +1,4 @@
+-// +build !linux,!windows,!darwin,!aix,!dragonfly,!freebsd,!netbsd,!openbsd,!solaris
++// +build !linux,!windows,!darwin,!aix,!dragonfly,!freebsd,!netbsd,!openbsd,!solaris,!zos
+ 
+ // The above build constraint must contain the negation of all of the build
+ // constraints found in the other app_*.go files, to catch any other OS
+diff --git a/userdirs/app_unix.go b/userdirs/app_unix.go
+index 44493df..04e1f9d 100644
+--- a/userdirs/app_unix.go
++++ b/userdirs/app_unix.go
+@@ -1,4 +1,4 @@
+-// +build linux aix dragonfly freebsd netbsd openbsd solaris
++// +build linux aix dragonfly freebsd netbsd openbsd solaris zos
+ 
+ package userdirs
+ 
+diff --git a/userdirs/app_unix_test.go b/userdirs/app_unix_test.go
+index 727a5d1..72be0eb 100644
+--- a/userdirs/app_unix_test.go
++++ b/userdirs/app_unix_test.go
+@@ -1,4 +1,4 @@
+-// +build linux aix dragonfly freebsd netbsd openbsd solaris
++// +build linux aix dragonfly freebsd netbsd openbsd solaris zos
+ 
+ package userdirs
+ 


### PR DESCRIPTION
Build is passed with below observations.

Reason for the below change, the **_go work init_** command cannot add speakeasy to the go.work file since it is only a util package and not a go module.. So, Until speakeasy releases a new version, we might attempt the modification below.

>  go mod tidy
>   chmod -R 755 ../go/pkg/mod/github.com/bgentry/speakeasy@v0.1.0/
>   cp ../speakeasy/* ../go/pkg/mod/github.com/bgentry/speakeasy@v0.1.0/
>   cat ../go/pkg/mod/github.com/bgentry/speakeasy@v0.1.0/speakeasy_unix.go

Build errors occurred in: github.com/hashicorp/terraform/internal/rpcapi
Package require manual porting: github.com/hashicorp/terraform/internal/rpcapi
	unknown type error(s) occurred in github.com/hashicorp/terraform/internal/rpcapi: [stacks.go:330:14: cannot infer Message (grpc_help for below command

> wharf ./terraform/...